### PR TITLE
Food POST Testing - Food Already Created

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 .env
 config/config.json
+coverage

--- a/specs/endpoints/food_create.spec.js
+++ b/specs/endpoints/food_create.spec.js
@@ -20,14 +20,6 @@ describe('Food create API', () => {
         name: "Pringles",
         calories: 27
       }
-      return request(app).post("/api/v1/foods").send(newFood)
-        .then(response => {
-          expect(response.status).toBe(200),
-            expect(response.body).toHaveProperty("id"),
-            expect(response.body.name).toBe("Pringles"),
-            expect(response.body.calories).toBe(27)
-        })
-
       const newFoodPringlesNotCapitalized = {
         name: "pringles",
         calories: 27
@@ -35,9 +27,16 @@ describe('Food create API', () => {
       return request(app).post("/api/v1/foods").send(newFood)
         .then(response => {
           expect(response.status).toBe(200),
-            expect(response.body.id).toBe(1),
+            expect(response.body).toHaveProperty("id"),
             expect(response.body.name).toBe("Pringles"),
             expect(response.body.calories).toBe(27)
+        })
+        .then(( ) => {
+          return request(app).post("/api/v1/foods").send(newFoodPringlesNotCapitalized)
+            .then(response => {
+              // This expectation will need to be changed to a 400 status code, as the object will already be in the database.
+              expect(response.status).toBe(200)
+            })
         })
     })
 


### PR DESCRIPTION
This pull request implements testing for the scenario in which a POST request is sent for a food that already exists by that name in the database.

We've discussed altering the status to be 404, rather than a 200, therefore this test expectation will need to be changed when that different functionality is implemented.

This pull request also adds `coverage` to the `.gitignore` so that we can utilize the command `npm test — —coverage` to monitor our test coverage.