### PR TITLE
05 09 19 meal create

### DIFF
--- a/routes/api/v1/meals.js
+++ b/routes/api/v1/meals.js
@@ -98,23 +98,23 @@ router.post("/:meal_id/foods/:food_id", async function(req, res, next) {
           })
           .spread((mealfood, created) => {
             if (created) {
-              res.status(200).send(JSON.stringify({"message": `Successfully added ${food.name} to ${meal.name}`}))
+              res.status(201).send(JSON.stringify({"message": `Successfully added ${food.name} to ${meal.name}`}))
             }else{
               res.status(400).send({error:"That food already exists for that meal."})
             }
           })
           .catch(error => {
-            res.status(404).send({ error: error });
+            res.status(400).send({ error: error });
           })
         }
       })
       .catch(error => {
-        res.status(404).send({ error: "Invalid request." });
+        res.status(400).send({ error: "Invalid request." });
       })
     }
   })
   .catch(error => {
-    res.status(404).send({ error: "Invalid request." });
+    res.status(400).send({ error: "Invalid request." });
   })
 })
 


### PR DESCRIPTION
As a user sending a POST request to /api/v1/meals/:meal_id/foods/:id, it adds the food with :id to the meal with :meal_id.

MealFood item creation complete. Adding tests in separate PR after test bug fixes are merged. There is not a "meal" creation endpoint in the spec. We should discuss if we want to create a limited selection of meals (through the seed file) and enable a user to create a custom meal.